### PR TITLE
Add Instructions and Version Guide For Poke Portal News

### DIFF
--- a/Released/Gen 9/Raid Events/readme.md
+++ b/Released/Gen 9/Raid Events/readme.md
@@ -1,0 +1,12 @@
+# Poké Portal News (Raid Events)
+
+## Instructions
+To import these files into your save, use PKHeX's block importing function. Our [tutorial](https://projectpokemon.org/home/tutorials/save-editing/gen-9/gen-9-specific-edits-importing-poké-portal-news-raid-events-r124/) should guide you through it.
+
+## Version Guide
+| Version | Starting Raid Index | Ending Raid Index |
+|---------|---------------------|-------------------|
+| 1.0.1   | 000                 | 001               |
+| 1.1.0   | 002                 | 012               |
+| 1.2.0   | 013                 | 018               |
+| 1.3.0   | 019                 |                   |


### PR DESCRIPTION
- Add instructions with link to the forum tutorial for importing blocks.
- Given that the filenames of the recent raids end with the version number, make a note of which raids were released during a version's "tenure".