### PR TITLE
Refactor Encounters.txt with periods instead of commas for preventing future parsing issues

### DIFF
--- a/Released/Gen 9/Outbreak Events/024 Flying Pokemon Outbreaks/Encounters.txt
+++ b/Released/Gen 9/Outbreak Events/024 Flying Pokemon Outbreaks/Encounters.txt
@@ -2,12 +2,12 @@ Event Outbreak Identifier: 20250207
 
 Fletchling Mass Outbreak
 	Level: 10-65
-	Shiny: 0,5% rate
+	Shiny: 0.5% rate
 
 Starly Mass Outbreak
 	Level: 10-65
-	Shiny: 0,5% rate
+	Shiny: 0.5% rate
 
 Pikipek Mass Outbreak
 	Level: 10-65
-	Shiny: 0,5% rate
+	Shiny: 0.5% rate


### PR DESCRIPTION
Refactor suggestion

Replace comma with period in decimal numbers.

The shiny rates use comma as decimal separator (0,5%). This could cause parsing issues in some systems. Consider using period instead (0.5%).